### PR TITLE
Fix color bet payout calculation

### DIFF
--- a/server/services/index.js
+++ b/server/services/index.js
@@ -153,7 +153,7 @@ let calculateEarnings = (betValues) => {
     let valuesAllowed = betsAllowed.numbers.none.concat(betsAllowed.numbers.red, betsAllowed.numbers.black)
     if (betValues.bet.length == 1 && String(betValues.bet) === '0') {
         earnings = parseFloat(betValues.amount) / 2
-    } else if (betsAllowed.colors.includes(parseInt(betValues.bet))) {
+    } else if (betsAllowed.colors.includes(String(betValues.bet).toLowerCase())) {
         earnings = (parseInt(betValues.amount) * 2) + parseInt(betValues.amount)
     } else if (valuesAllowed.includes(parseInt(betValues.bet))) {
         earnings = (parseInt(betValues.amount) * 35) + parseInt(betValues.amount)


### PR DESCRIPTION
## Summary
- fix winnings calculation for color bets in `calculateEarnings`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f7cacf0bc832bb29de6065e4af8f0